### PR TITLE
fix: types definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -194,5 +194,5 @@ export declare function defineDrosseServer(
   config: DrosseServerConfig
 ): DrosseServerConfig
 
-export declare function defineDrosseService(cb: DrosseServiceCallback): void
-export declare function defineDrosseScraper(cb: DrosseScraperCallback): void
+export declare function defineDrosseService(cb: DrosseServiceCallback): DrosseServiceCallback
+export declare function defineDrosseScraper(cb: DrosseScraperCallback): DrosseScraperCallback


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.3.1--canary.62.4427454538.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @jota-one/drosse@3.3.1--canary.62.4427454538.0
  # or 
  yarn add @jota-one/drosse@3.3.1--canary.62.4427454538.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
